### PR TITLE
chore: fixed template capitalize issue and naming

### DIFF
--- a/templates/doctors/doctor_detail.html
+++ b/templates/doctors/doctor_detail.html
@@ -7,7 +7,7 @@
 {% block body %}
 
 <div class="p-3">
-	<h4>{{ doctor.first_name }} {{ doctor.last_name }}</h4>
+	<h4 style="text-transform: capitalize;">{{ doctor.first_name }} {{ doctor.last_name }}</h4>
 </div>
 
 {% include 'components/back_button.html' %}

--- a/templates/doctors/doctor_list.html
+++ b/templates/doctors/doctor_list.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %} Patient List {% endblock %}
+{% block title %} Doctors List {% endblock %}
 
 
 {% block body %}


### PR DESCRIPTION
**PR Description**
- Changed the title of Doctors list page from `patient list` to `doctors list`.
- Added `capitalize style` to the heading in the doctors details page.